### PR TITLE
fix:解决监听输入框文本变化失效的问题

### DIFF
--- a/harmony/keyboard_controller/src/main/cpp/KeyboardControllerViewComponentInstance.cpp
+++ b/harmony/keyboard_controller/src/main/cpp/KeyboardControllerViewComponentInstance.cpp
@@ -191,6 +191,11 @@ void KeyboardControllerViewComponentInstance::onChange(std::string text) {
      }
 
 }
+
+void KeyboardControllerViewComponentInstance::onChange(std::string text, std::string extendStr) {
+    onChange(std::move(text));
+}
+
 void KeyboardControllerViewComponentInstance::onTextSelectionChange(int32_t location, int32_t length) {
     DLOG(INFO) << " onKeyboardControllerView onTextSelectionChange";
     // to do

--- a/harmony/keyboard_controller/src/main/cpp/KeyboardControllerViewComponentInstance.h
+++ b/harmony/keyboard_controller/src/main/cpp/KeyboardControllerViewComponentInstance.h
@@ -68,6 +68,7 @@ public:
     void onClick() override;
     // textArea textInput delegate
     void onChange(std::string text) override;
+    void onChange(std::string text, std::string extendStr) override;
     void onBlur() override;
     void onFocus() override;
     void onTextSelectionChange(int32_t location, int32_t length) override;


### PR DESCRIPTION
# Summary

- fix:解决监听输入框文本变化失效的问题
- https://github.com/react-native-oh-library/react-native-keyboard-controller/issues/76
- 
## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

## Version Info
- react-native-harmony: 0.82.27
- DevEco Studio 6.0.1 Release
- Ohos_sdk_public 6.0.1.116 
- ROM: 6.0.0.130