### PR TITLE
fix:修复状态栏颜色值转换错误

### DIFF
--- a/harmony/keyboard_controller/src/main/ets/RNStatusBarManagerCompatTurboModule.ts
+++ b/harmony/keyboard_controller/src/main/ets/RNStatusBarManagerCompatTurboModule.ts
@@ -88,7 +88,7 @@ export  class RNStatusBarManagerCompatTurboModule extends TurboModule implements
   async  setColor(color: number, animated: boolean): Promise<void> {
     Logger.info("###turboModule setColor");
     let newSystemBarProperty: window.SystemBarProperties = {
-      statusBarColor: color.toString(),
+      statusBarColor: this.toHarmonyColor(color),
       enableStatusBarAnimation:animated
     };
     this.setWindowSystemBarProperties(newSystemBarProperty)
@@ -112,6 +112,15 @@ export  class RNStatusBarManagerCompatTurboModule extends TurboModule implements
       statusBarContentColor:themeFlag?"#000000":"#ffffff",
     };
     this.setWindowSystemBarProperties(newSystemBarProperty)
+  }
+
+  private toHarmonyColor(color: number): string {
+    const unsignedColor = color >>> 0;
+    const hex = unsignedColor > 0xffffff
+      ? unsignedColor.toString(16).padStart(8, '0')
+      : unsignedColor.toString(16).padStart(6, '0');
+
+    return `#${hex}`;
   }
 
 }


### PR DESCRIPTION
### Description (描述 / Summary)

```markdown
# Summary

## 动机 / Motivation

- **这个问题修复了什么？ / What issue does this PR solve?**
  在鸿蒙平台下，`StatusBarManagerCompat.setColor()` 传入的颜色值是 `number` 类型（例如 `0xFF0000`）。在原实现中直接调用了 `color.toString()`，导致输出为十进制整数字符串（如 `"16711680"`）而非 ArkUI 所需的十六进制颜色格式（如 `"#FF0000"` 或 `"#FFFF0000"`），从而引发颜色设置失败的问题。
  
  In the HarmonyOS implementation, the color value passed to `StatusBarManagerCompat.setColor()` is a `number` (e.g., `0xFF0000`). The original code used `color.toString()`, which converted it to a decimal string (`"16711680"`) instead of the hex format (`"#FF0000"` or `"#FFFF0000"`) required by ArkUI. This caused the status bar color setup to fail.

- **如何实现的解决方案？ / How did you implement the solution?**
  在 `RNStatusBarManagerCompatTurboModule` 中增加私有辅助方法 `toHarmonyColor(color: number)`。通过无符号右移操作处理颜色值，并将其转换为以 `#` 开头的十六进制字符串（支持 RGB 与 ARGB 格式自动补齐），确保系统可以正确识别颜色。
  
  Added a private helper method `toHarmonyColor(color: number)` in `RNStatusBarManagerCompatTurboModule`. It processes the color value using unsigned right-shift operations and converts it into a hex-encoded string starting with `#` (supporting both RGB and ARGB padding), which allows the system to resolve the color properly.

- **影响范围 / What areas of the library does it impact?**
  影响鸿蒙端状态栏颜色设置的相关功能 (`StatusBarManagerCompat`)。
  
  Affects the status bar color setting functionality on HarmonyOS (`StatusBarManagerCompat`).

## Test Plan

1. 在 React Native 代码中调用 `StatusBarManagerCompat.setColor(0xFF0000, true)`。
2. 观察真机/模拟器日志与实际界面：
   - 转换函数正常将 `16711680` 转为了 `"#ff0000"`。
   - 状态栏颜色成功改变，未出现设置失败的情况。

1. Invoke `StatusBarManagerCompat.setColor(0xFF0000, true)` from the React Native side.
2. Verify on a real device/simulator:
   - The conversion method correctly maps `16711680` to `"#ff0000"`.
   - The status bar color updates successfully without failure.

## Checklist

- [x] 已经在真机设备或模拟器上测试通过 / I have tested this on a device and a simulator
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比 / I have already compared the effects/features with the Android or iOS platforms
- [ ] 已经添加了对应 API 的测试用例（如需要） / I added a test for the API (if applicable)
- [ ] 已经更新了文档（如需要） / I updated the documentation (if applicable)
- [ ] 更新了 JS/TS 代码 (如有) / I have updated the JS/TS (if applicable)